### PR TITLE
RP.I2C_Master: fix transmit and target addresses

### DIFF
--- a/src/drivers/rp-i2c_master.ads
+++ b/src/drivers/rp-i2c_master.ads
@@ -67,7 +67,8 @@ private
       (Num    : I2C_Number;
        Periph : not null access RP2040_SVD.I2C.I2C_Peripheral)
    is new HAL.I2C.I2C_Port with record
-      Do_Stop_Sequence : Boolean := True;
+      No_Stop : Boolean := False;
+      Restart_On_Next : Boolean := False;
    end record;
 
 end RP.I2C_Master;


### PR DESCRIPTION
This fixes the transmit procedure when used in a mem_write/mem_read
operation (transmit followed by receive or transmit). The procedure is
now closer to the reference implementation of the SDK.