### PR TITLE
RP.PIO: fix JMP target address depending on program offset

### DIFF
--- a/src/drivers/rp-pio.adb
+++ b/src/drivers/rp-pio.adb
@@ -369,9 +369,21 @@ package body RP.PIO is
        Prog        : Program;
        Offset      : PIO_Address)
    is
+      Insn : PIO_Instruction;
    begin
       for I in Prog'Range loop
-         This.Periph.INSTR_MEM (Offset + I - Prog'First) := UInt32 (Prog (I));
+         Insn := Prog (I);
+         
+         --  Check for JMP instruction
+         if (Insn and 2#111_00000_000_00000#) = 2#000_00000_000_00000# then
+            --  JMP instructions use absolute target addresses. If the program
+            --  is loaded at an offset, the JMP targets have to be adjusted with
+            --  this offset.
+            
+            Insn := Insn + PIO_Instruction (Offset);
+         end if;
+
+         This.Periph.INSTR_MEM (Offset + I - Prog'First) := UInt32 (Insn);
       end loop;
    end Load;
 


### PR DESCRIPTION
I was trying to load and run a program at an offset and I realized that the JMP addresses would be wrong.
I checked the PICO SDK and they do adjust the JMP targets:
https://github.com/raspberrypi/pico-sdk/blob/bfcbefafc5d2a210551a4d9d80b4303d4ae0adf7/src/rp2_common/hardware_pio/pio.c#L110

There's one thing I am not sure about: what does the `.origin` pioasm directive does?
For the Ada output it seems like the directive is ignored. 

One could also implement a better `PIOASM` package to make a cleaner detection and modification of JMP instructions.
For instance to check that the applied offset will not overflow the address field of the instruction