### PR TITLE
Replace boot2 GPL license headers with BSD-3-Clause.

### DIFF
--- a/boot2/memory-map.ld
+++ b/boot2/memory-map.ld
@@ -1,38 +1,8 @@
-/****************************************************************************
- *                                                                          *
- *                         GNAT COMPILER COMPONENTS                         *
- *                                                                          *
- *                                  A R M                                   *
- *                                                                          *
- *                            Linker Script File                            *
- *                                                                          *
- *      Copyright (C) 1999-2002 Universidad Politecnica de Madrid           *
- *             Copyright (C) 2003-2006 The European Space Agency            *
- *                   Copyright (C) 2003-2021 AdaCore                        *
- *                                                                          *
- * GNAT is free software;  you can  redistribute it  and/or modify it under *
- * terms of the  GNU General Public License as published  by the Free Soft- *
- * ware  Foundation;  either version 2,  or (at your option) any later ver- *
- * sion.  GNAT is distributed in the hope that it will be useful, but WITH- *
- * OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY *
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License *
- * for  more details.  You should have  received  a copy of the GNU General *
- * Public License  distributed with GNAT;  see file COPYING.  If not, write *
- * to  the  Free Software Foundation,  51  Franklin  Street,  Fifth  Floor, *
- * Boston, MA 02110-1301, USA.                                              *
- *                                                                          *
- * As a  special  exception,  if you  link  this file  with other  files to *
- * produce an executable,  this file does not by itself cause the resulting *
- * executable to be covered by the GNU General Public License. This except- *
- * ion does not  however invalidate  any other reasons  why the  executable *
- * file might be covered by the  GNU Public License.                        *
- *                                                                          *
- * GNARL was developed by the GNARL team at Florida State University.       *
- * Extensive contributions were provided by Ada Core Technologies, Inc.     *
- * The  executive  was developed  by the  Real-Time  Systems  Group  at the *
- * Technical University of Madrid.                                          *
- *                                                                          *
- ****************************************************************************/
+/*
+ * Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
  
 /* The stage 2 bootloader must fit in 256 bytes. 
  * The last 4 bytes are reserved for the CRC32

--- a/boot2/src/boot2_entry.S
+++ b/boot2/src/boot2_entry.S
@@ -1,29 +1,8 @@
-############################################################################
-#                                                                          #
-#                         GNAT RUN-TIME COMPONENTS                         #
-#                                                                          #
-#                      Copyright (C) 2021, AdaCore                         #
-#                                                                          #
-# GNAT is free software;  you can  redistribute it  and/or modify it under #
-# terms of the  GNU General Public License as published  by the Free Soft- #
-# ware  Foundation;  either version 3,  or (at your option) any later ver- #
-# sion.  GNAT is distributed in the hope that it will be useful, but WITH- #
-# OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY #
-# or FITNESS FOR A PARTICULAR PURPOSE.                                     #
-#                                                                          #
-# As a special exception under Section 7 of GPL version 3, you are granted #
-# additional permissions described in the GCC Runtime Library Exception,   #
-# version 3.1, as published by the Free Software Foundation.               #
-#                                                                          #
-# You should have received a copy of the GNU General Public License and    #
-# a copy of the GCC Runtime Library Exception along with this program;     #
-# see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    #
-# <http://www.gnu.org/licenses/>.                                          #
-#                                                                          #
-# GNAT was originally developed  by the GNAT team at  New York University. #
-# Extensive contributions were provided by Ada Core Technologies Inc.      #
-#                                                                          #
-############################################################################
+/*
+ *  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ */
 
 .syntax unified
 .cpu cortex-m0

--- a/boot2/src/generic_03/boot2.adb
+++ b/boot2/src/generic_03/boot2.adb
@@ -1,29 +1,8 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
 
 --  The SSI cannot be configured while enabled, so the boot ROM copies the
 --  first 256 bytes of flash (referred to by the linker as .boot2) to SRAM and

--- a/boot2/src/generic_03/boot2.ads
+++ b/boot2/src/generic_03/boot2.ads
@@ -1,29 +1,8 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
 
 procedure Boot2 with
   No_Elaboration_Code_All;

--- a/boot2/src/generic_03/boot2_generic_03.ads
+++ b/boot2/src/generic_03/boot2_generic_03.ads
@@ -1,29 +1,9 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
+
 with Interfaces; use Interfaces;
 
 package Boot2_Generic_03 with

--- a/boot2/src/qspi/boot2.adb
+++ b/boot2/src/qspi/boot2.adb
@@ -1,29 +1,8 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
 
 --  The SSI cannot be configured while enabled, so the boot ROM copies the
 --  first 256 bytes of flash (referred to by the linker as .boot2) to SRAM and

--- a/boot2/src/qspi/boot2.ads
+++ b/boot2/src/qspi/boot2.ads
@@ -1,29 +1,8 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
 
 procedure Boot2 with
   No_Elaboration_Code_All;

--- a/boot2/src/qspi/boot2_register_values.ads
+++ b/boot2/src/qspi/boot2_register_values.ads
@@ -1,29 +1,9 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
+
 with Interfaces;   use Interfaces;
 with Flash_Config;
 

--- a/boot2/src/qspi/generic_qspi/flash_config.ads
+++ b/boot2/src/qspi/generic_qspi/flash_config.ads
@@ -1,29 +1,9 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
+
 with Interfaces; use Interfaces;
 
 --  This configuration is compatible with most flash devices, except for

--- a/boot2/src/qspi/w25qxx/flash_config.ads
+++ b/boot2/src/qspi/w25qxx/flash_config.ads
@@ -1,29 +1,9 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
+
 with Interfaces; use Interfaces;
 
 --  This configuration is compatible with Winbond devices only:

--- a/boot2/src/registers.ads
+++ b/boot2/src/registers.ads
@@ -1,29 +1,9 @@
-------------------------------------------------------------------------------
---                                                                          --
---                         GNAT RUN-TIME COMPONENTS                         --
---                                                                          --
---                      Copyright (C) 2021, AdaCore                         --
---                                                                          --
--- GNAT is free software;  you can  redistribute it  and/or modify it under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
--- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
--- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
--- GNAT was originally developed  by the GNAT team at  New York University. --
--- Extensive contributions were provided by Ada Core Technologies Inc.      --
---                                                                          --
-------------------------------------------------------------------------------
+--
+--  Copyright (C) 2021 Daniel King <damaki.gh@gmail.com>
+--
+--  SPDX-License-Identifier: BSD-3-Clause
+--
+
 with Interfaces;
 with System;
 


### PR DESCRIPTION
I believe @damaki still retains the original copyright to these files, which have never been merged into an AdaCore repository. If he approves this pull request, then we'll consider rp2040_hal to be 100% BSD licensed.