### PR TITLE
RP.PIO.WS2812: Do not enable/reset the PIO at init

### DIFF
--- a/src/drivers/rp-pio-ws2812.adb
+++ b/src/drivers/rp-pio-ws2812.adb
@@ -38,7 +38,6 @@ package body RP.PIO.WS2812 is
 
    begin
       This.Pin.Configure (Output, Pull_Up, This.PIO.GPIO_Function);
-      This.PIO.Enable;
 
       This.PIO.Load
          (Prog   => WS2812_PIO.Ws2812_Program_Instructions,


### PR DESCRIPTION
The RP.PIO.Enable procedure actually does a reset of the PIO device,
Therefore if we call it during RP.PIO.WS2812.Initialize the configuration
of other state machines of the given PIO will also be reset. 

If one tries, for instance, to have two WS2812 strips on the same PIO but
different state machines, init of the second strip will reset the configuration 
for the first. This means the first strip will never work.