### PR TITLE
RP.DMA: fix IRQ1 handling

### DIFF
--- a/src/drivers/rp-dma.adb
+++ b/src/drivers/rp-dma.adb
@@ -141,8 +141,14 @@ package body RP.DMA is
             when 1 => RP2040_SVD.Interrupts.DMA_IRQ_1_Interrupt);
 
    begin
-      DMA_Periph.IRQ (IRQ).INTE.INTE0 :=
-        DMA_Periph.IRQ (IRQ).INTE.INTE0 or Mask;
+      case IRQ is
+         when 0 =>
+            DMA_Periph.IRQ0.INTE.INTE0 :=
+              DMA_Periph.IRQ0.INTE.INTE0 or Mask;
+         when 1 =>
+            DMA_Periph.IRQ1.INTE.INTE0 :=
+              DMA_Periph.IRQ1.INTE.INTE0 or Mask;
+      end case;
 
       Cortex_M.NVIC.Clear_Pending (Line);
       Cortex_M.NVIC.Enable_Interrupt (Line);
@@ -157,8 +163,14 @@ package body RP.DMA is
    is
       Mask : constant UInt16 := Shift_Left (UInt16 (1), Natural (Channel));
    begin
-      DMA_Periph.IRQ (IRQ).INTE.INTE0 :=
-        DMA_Periph.IRQ (IRQ).INTE.INTE0 and (not Mask);
+      case IRQ is
+         when 0 =>
+            DMA_Periph.IRQ0.INTE.INTE0 :=
+              DMA_Periph.IRQ0.INTE.INTE0 and (not Mask);
+         when 1 =>
+            DMA_Periph.IRQ1.INTE.INTE0 :=
+              DMA_Periph.IRQ1.INTE.INTE0 and (not Mask);
+      end case;
    end Disable_IRQ;
 
    -------------
@@ -170,7 +182,12 @@ package body RP.DMA is
    is
       Mask : constant UInt16 := Shift_Left (UInt16 (1), Natural (Channel));
    begin
-      DMA_Periph.IRQ (IRQ).INTS.INTS0 := Mask;
+      case IRQ is
+         when 0 =>
+            DMA_Periph.IRQ0.INTS.INTS0 := Mask;
+         when 1 =>
+            DMA_Periph.IRQ1.INTS.INTS0 := Mask;
+      end case;
    end Ack_IRQ;
 
    ----------------
@@ -183,7 +200,12 @@ package body RP.DMA is
    is
       Mask : constant UInt16 := Shift_Left (UInt16 (1), Natural (Channel));
    begin
-      return (DMA_Periph.IRQ (IRQ).INTS.INTS0 and Mask) /= 0;
+      case IRQ is
+         when 0 =>
+            return (DMA_Periph.IRQ0.INTS.INTS0 and Mask) /= 0;
+         when 1 =>
+            return (DMA_Periph.IRQ1.INTS.INTS0 and Mask) /= 0;
+      end case;
    end IRQ_Status;
 
    procedure Set_Pacing_Timer

--- a/src/drivers/rp-dma.ads
+++ b/src/drivers/rp-dma.ads
@@ -304,14 +304,13 @@ private
 
    type DMA_Channels_Debug is array (DMA_Channel_Id) of DMA_Channel_Debug;
 
-   type DMA_IRQs is array (0 .. 1) of aliased DMA_IRQ;
-
    type DMA_Timers is array (DMA_Timer_Id) of RP2040_SVD.DMA.TIMER_Register;
 
    type DMA_Peripheral is record
       CH                 : DMA_Channels;
       INTR               : aliased RP2040_SVD.DMA.INTR_Register;
-      IRQ                : DMA_IRQs;
+      IRQ0               : DMA_IRQ;
+      IRQ1               : DMA_IRQ;
       TIMER              : DMA_Timers;
       MULTI_CHAN_TRIGGER : aliased RP2040_SVD.DMA.MULTI_CHAN_TRIGGER_Register;
       SNIFF_CTRL         : aliased RP2040_SVD.DMA.SNIFF_CTRL_Register;
@@ -325,7 +324,8 @@ private
    for DMA_Peripheral use record
       CH                 at 16#000# range 0 .. 6143;
       INTR               at 16#400# range 0 .. 31;
-      IRQ                at 16#404# range 0 .. 191;
+      IRQ0               at 16#404# range 0 .. 95;
+      IRQ1               at 16#414# range 0 .. 95;
       TIMER              at 16#420# range 0 .. 127;
       MULTI_CHAN_TRIGGER at 16#430# range 0 .. 31;
       SNIFF_CTRL         at 16#434# range 0 .. 31;


### PR DESCRIPTION
There is a reserved word between the INTS0 and INTE1 which is not represented in the current DMA_IRQs array. As a result, all register accesses for IRQ1 are incorrect.

Adding a field to the DMA_IRQ record, either at the beginning or the end, would overlap one the registers surrounding the DMA_IRQs array (INTR or TIMER). The solution used here is to split the array in two separate fields.