### PR TITLE
add Reset_Core1 as copy from bb_runtimes

### DIFF
--- a/src/drivers/rp-multicore.adb
+++ b/src/drivers/rp-multicore.adb
@@ -6,12 +6,35 @@
 with System.Storage_Elements;
 with RP2040_SVD.Interrupts;
 with RP2040_SVD.SIO;
+with RP2040_SVD.PSM;
 with Cortex_M.Hints;
 with Cortex_M.NVIC;
 
 with RP.Multicore.FIFO;
 
 package body RP.Multicore is
+
+   ------------------
+   -- Reset_Core1 --
+   ------------------
+
+   procedure Reset_Core1 is
+      use RP2040_SVD.PSM;
+   begin
+      --  Hard reset core 1.
+      PSM_Periph.FRCE_OFF := (proc   => (As_Array => True,
+                                         Arr      => (0 => False,
+                                                      1 => True)),
+                              others => <>);
+
+      --  Wait until core1 has been powered off.
+      loop
+         exit when PSM_Periph.FRCE_OFF.proc.Arr (1) = True;
+      end loop;
+
+      --  Release core1 from reset.
+      PSM_Periph.FRCE_OFF := (others => <>);
+   end Reset_Core1;
 
    ------------------
    -- Launch_Core1 --

--- a/src/drivers/rp-multicore.ads
+++ b/src/drivers/rp-multicore.ads
@@ -10,6 +10,9 @@ package RP.Multicore
    with Preelaborate
 is
 
+   procedure Reset_Core1;
+   --  hard reset core1
+
    procedure Launch_Core1
       (Trap_Vector   : HAL.UInt32;
        Stack_Pointer : HAL.UInt32;


### PR DESCRIPTION
As it was discussed [here](https://forum.ada-lang.io/t/using-both-cores-of-rp2040/3853/15?u=rree) the start of programs on core1 requires a clear reset of core1. The routine `Reset_Core1` provides that functionality. It is direct copy of the corresponding routine from bb_runtime.