### PR TITLE
Allow building with gnat_arm_elf=15.2.1

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -14,7 +14,7 @@ cortex_m = "^1"
 atomic = "^1"
 hal = "^1"
 usb_embedded = "^1"
-gnat_arm_elf = "^14"
+gnat_arm_elf = ">=14 & /=15.1.2"
 
 [configuration.variables]
 Flash_Chip = {type = "Enum",  values = ["w25qxx", "generic_qspi", "generic_03"], default = "w25qxx"}

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -12,7 +12,7 @@ executables = ["test_rp2040_hal"]
 rp2040_hal = "^2"
 aunit = "^24"
 gnatcov = "^22"
-gnat_arm_elf = "^14"
+gnat_arm_elf = ">=14"
 
 [[pins]]
 rp2040_hal = { path='..' }
@@ -22,6 +22,7 @@ AUNIT_RUNTIME = "zfp-cross"
 
 [build-profiles]
 "*" = "validation"
+cortex_m = "release"
 usb_embedded = "release"
 atomic = "release"
 aunit = "release"


### PR DESCRIPTION
It turns out that the compilation error described in #70 only happens with gnat_arm_elf version 15.1.2. The more recent 15.2.1 seems to fix that problem and I am able to build the rp2040_hal tests with version 15.2.1.

These changes allow building with more recent versions of gnat, and explicitly excludes gnat_arm_elf version 15.1.2 from the dependency solution.

I also had to force `cortex_m` into `release` mode for the tests as in `validation` mode a style error (unused parameter) prevents `semihosting-filesystem.adb` from compiling.

What do you think?

Fixes #70 