### PR TITLE
Add Current_Instruction_Address function to RP.PIO

### DIFF
--- a/src/drivers/rp-pio.adb
+++ b/src/drivers/rp-pio.adb
@@ -674,4 +674,10 @@ package body RP.PIO is
        return RP.DMA.DMA_Request_Trigger
    is (RP.DMA.DMA_Request_Trigger'Val (This.Num * 8 + Natural (SM) + 4));
 
+   function Current_Instruction_Address
+      (This : PIO_Device;
+       SM   : PIO_SM)
+       return PIO_Address
+   is (PIO_Address (This.Periph.SM (SM).ADDR.SM0_ADDR));
+
 end RP.PIO;

--- a/src/drivers/rp-pio.ads
+++ b/src/drivers/rp-pio.ads
@@ -349,6 +349,12 @@ is
        SM   : PIO_SM)
        return RP.DMA.DMA_Request_Trigger;
 
+   function Current_Instruction_Address
+      (This : PIO_Device;
+       SM   : PIO_SM)
+       return PIO_Address;
+   --  Current instruction address of the given state machine.
+
 private
 
    function Div_Integer


### PR DESCRIPTION
In some case you need current instruction address of a PIO State Machine. Like this: https://iosoft.blog/2022/12/06/picowi_part1/