### PR TITLE
Fix PWM slice calculation for RP2350 in RP.PWM.To_PWM

### DIFF
--- a/src/devices/rp2350/rp-pwm.adb
+++ b/src/devices/rp2350/rp-pwm.adb
@@ -160,9 +160,9 @@ package body RP.PWM is
       Slice    : UInt32 := Shift_Right (Pin, 1);
    begin
       if Pin < 32 then
-         Slice := Pin and 2#111#;
+         Slice := Slice and 2#111#;
       else
-         Slice := 8 + (Pin and 2#11#);
+         Slice := 8 + (Slice and 2#11#);
       end if;
       return PWM_Point'
          (Slice   => PWM_Slice (Slice),


### PR DESCRIPTION
The function performed a Shift_Right (Pin, 1) but then ignored the result and overwrote Slice with:

    Slice := Pin and 2#111#;

for all pins below 32. The fix uses the already shifted value for the mask operation:

    Slice := Slice and 2#111#;

This brings the calculation in line with the RP2350 PWM GPIO mapping table in the datasheet.

Tested on Raspberry Pi Pico 2 (RP2350):
- GPIO14 now correctly maps to slice 7, channel A
- GPIO15 now correctly maps to slice 7, channel B

The change eliminates slice misconfiguration when multiple GPIOs share
the same PWM slice, which previously caused missing or flickering PWM
outputs on the Pico 2.