### PR TITLE
This.PIO.Enable is missing.

### DIFF
--- a/src/drivers/rp-pio-ws2812.adb
+++ b/src/drivers/rp-pio-ws2812.adb
@@ -39,6 +39,7 @@ package body RP.PIO.WS2812 is
    begin
       This.Pin.Configure (Output, Pull_Up, This.PIO.GPIO_Function);
 
+      This.PIO.Enable;
       This.PIO.Load
          (Prog   => WS2812_PIO.Ws2812_Program_Instructions,
           Offset => ASM_Offset);


### PR DESCRIPTION
Same here. But I just noted you don't use develop. You develop on master. So I guess I prepare another pull request.